### PR TITLE
ELEMENTS-208: Fix display on IE

### DIFF
--- a/dataviz/nuxeo-document-distribution-chart.html
+++ b/dataviz/nuxeo-document-distribution-chart.html
@@ -374,7 +374,7 @@ Example:
           return query;
         },
 
-        _computeQueryFilter(mode, path) {
+        _computeQueryFilter: function(mode, path) {
           var result = [];
           if (this.onlyFolder && this.mode !== 'size') {
             result.push({


### PR DESCRIPTION
I seems that Internet Explorer does not like when a function is missing the " : function " when declared.
This would solve the problem.