### PR TITLE
Use polyfill for Array.prototype.find

### DIFF
--- a/nuxeo-slots.html
+++ b/nuxeo-slots.html
@@ -19,6 +19,29 @@ limitations under the License.
 <dom-module id="nuxeo-slot">
   <script>
     (function() {
+      if (!Array.prototype.find) { // polyfill to use Array.prototype.find
+        Object.defineProperty(Array.prototype, 'find', {
+          value: function(predicate) {
+           'use strict';
+           if (this == null) {
+             throw new TypeError('Array.prototype.find called on null or undefined');
+           }
+           if (typeof predicate !== 'function') {
+             throw new TypeError('predicate must be a function');
+           }
+           var list = Object(this);
+           var length = list.length >>> 0;
+           var thisArg = arguments[1];
+
+           for (var i = 0; i !== length; i++) {
+             if (predicate.call(thisArg, this[i], i, list)) {
+               return this[i];
+             }
+           }
+           return undefined;
+          }
+        });
+      }
 
       // global slot registry
       var REGISTRY = {};


### PR DESCRIPTION
As described in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find#Polyfill ,
the function Array.prototype.find is very recent and not recognized by a lot of browsers at the moment.

I took the snippet from the same documentation page, and I can now use slots in my application