### PR TITLE
ELEMENTS-270: fix select2 crash on IE11

### DIFF
--- a/widgets/nuxeo-select2-behavior.html
+++ b/widgets/nuxeo-select2-behavior.html
@@ -283,6 +283,11 @@ limitations under the License.
 
       jQuery(el).on('change', this._updateSelection.bind(this));
 
+      // fix for IE11 crash
+      document.addEventListener('click', function() {
+        jQuery(this._el).select2('close');
+      }.bind(this));
+
       // view or edit mode
       if (this.readonly) {
         jQuery(el).select2('readonly', true);

--- a/widgets/nuxeo-select2-theme.html
+++ b/widgets/nuxeo-select2-theme.html
@@ -132,6 +132,7 @@
     /* styles required for IE to work */
     background-color: #fff;
     filter: alpha(opacity=0);
+    visibility: hidden !important; /* fix for IE11 crash */
   }
 
   .select2-drop {


### PR DESCRIPTION
This is a hack/workaround to fix select2 crash on IE11