### PR TITLE
Enable setting slot model by slot-content

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
     "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#~1.0.2",
     "iron-elements": "PolymerElements/iron-elements#^1.0.0",
     "paper-elements": "PolymerElements/paper-elements#^1.0.1",
-    "nuxeo-elements": "nuxeo/nuxeo-elements#master",
+    "nuxeo-elements": "~1.0.0",
     "gold-email-input": "PolymerElements/gold-email-input#^1.0.6",
     "better-dateinput-polyfill": "1.5.2",
     "moment": "2.10.6",

--- a/nuxeo-slots.html
+++ b/nuxeo-slots.html
@@ -56,6 +56,14 @@ limitations under the License.
         }
       }
 
+      function _setSlotModel(slot, model) {
+        var registry = _getRegistry(slot);
+        registry.slots.forEach(function(c) {
+          c.model = model;
+          c._updateContent();
+        });
+      }
+
       /**
        * Custom element to help build pluggable applications.
        * Slots allow dynamic registration of content which will be stamped in the slot's parent.
@@ -272,6 +280,12 @@ limitations under the License.
         _unregister: function(slots) {
           slots.split(',').forEach(function(slot) {
             _unregisterContent(this, slot);
+          }.bind(this))
+        },
+
+        _setSlotModel: function(model) {
+          this.slot.split(',').forEach(function(slot) {
+            _setSlotModel(slot, model);
           }.bind(this))
         }
       });


### PR DESCRIPTION
Feature to set slot model inside nuxeo-slots.
So then users can define what slot should be visible inside the particular page, but still he can see same content. But with this feature user can set the model itself inside the slot so it's fully dynamic.