### PR TITLE
ELEMENTS-344: merge slot contents with no template

### DIFF
--- a/nuxeo-slots.html
+++ b/nuxeo-slots.html
@@ -42,7 +42,12 @@ limitations under the License.
         if (idx !== -1) {
           // if new content has same or higher priority then do the override
           if (node.priority >= registry.nodes[idx].priority) {
-            registry.nodes[idx] = node;
+            // if content has a template replace existing one
+            if (node.template) {
+              registry.nodes[idx] = node;
+            } else { // merge
+              registry.nodes[idx]._merge(node);
+            }
           }
         } else {
           registry.nodes.push(node);
@@ -149,7 +154,7 @@ limitations under the License.
           // keep track of stamped instances
           this._instances = [];
           _getRegistry(this.slot).nodes.forEach(function(node) {
-            var template = Polymer.dom(node).querySelector('template');
+            var template = node.template;
             if (!node.disabled && template) {
               this.templatize(template);
               var el = this.stamp(this.model);
@@ -260,6 +265,17 @@ limitations under the License.
 
         detached: function() {
           this._unregister(this.slot);
+        },
+
+        get template() {
+          return Polymer.dom(this).querySelector('template');
+        },
+
+        _merge: function(other) {
+          this.slot = other.slot;
+          this.disabled = other.disabled;
+          this.order = other.order;
+          this.priority = other.priority;
         },
 
         _slotChanged: function(_, oldSlot) {

--- a/test/nuxeo-slots.html
+++ b/test/nuxeo-slots.html
@@ -98,6 +98,24 @@ limitations under the License.
   </template>
 </test-fixture>
 
+<test-fixture id="disabledSlotContent">
+  <template>
+    <div>
+      <nuxeo-slot-content name="content" slot="SLOT1" disabled>
+        <template><span>Disabled content</span></template>
+      </nuxeo-slot-content>
+    </div>
+  </template>
+</test-fixture>
+
+<test-fixture id="reenabledSlotContent">
+  <template>
+    <div>
+      <nuxeo-slot-content name="content" slot="SLOT1"></nuxeo-slot-content>
+    </div>
+  </template>
+</test-fixture>
+
 <script>
 
   // return all children excluding <nuxeo-slot>
@@ -162,6 +180,17 @@ limitations under the License.
 
       fixture('slot1Content1Disabled');
       expect(_content(slot1)).to.be.empty;
+    });
+
+    test('slot content re-enabled', function() {
+
+      fixture('disabledSlotContent');
+      expect(_content(slot1)).to.be.empty;
+
+      fixture('reenabledSlotContent');
+      var content = _content(slot1);
+      expect(content.length).to.be.equal(1);
+      expect(content[0].textContent).to.be.equal('Disabled content');
     });
 
     test('slot content override', function() {


### PR DESCRIPTION
Goal if for slot content to only be overridden if the new contribution has a template.
This should allow enabling/disabling of slot contents without having to duplicate the original template.