### PR TITLE
fix(uploader-behavior): replace $.nx with prop connection

### DIFF
--- a/widgets/nuxeo-uploader-behavior.html
+++ b/widgets/nuxeo-uploader-behavior.html
@@ -92,7 +92,7 @@ limitations under the License.
     },
 
     batchExecute: function(operationId, params, headers) {
-      return this.$.nx.operation(operationId).then(function(operation) {
+      return this.connection.operation(operationId).then(function(operation) {
         var options = {};
         if (headers) {
           options['headers'] = headers;
@@ -146,7 +146,7 @@ limitations under the License.
     },
 
     _newBatch: function() {
-      return this.$.nx.batchUpload().then(function(uploader) {
+      return this.connection.batchUpload().then(function(uploader) {
         this.uploader = uploader;
       }.bind(this));
     },


### PR DESCRIPTION
Hi,

Just a simple fix on nuxeo-uploader-behavior

```javascript
if(!this.connection) {
   throw 'Missing connection';
 }
```
Property connection was not used and relying on an element id to use connection seems to limit the use of behavior.

For example, in nuxeo-web-ui, element [nuxeo-dropzone.html](https://github.com/nuxeo/nuxeo-web-ui/blob/84ddfb34b53d4e9a5207d40b24473474f44fa4d9/elements/nuxeo-dropzone/nuxeo-dropzone.html#L209) the property is set in ready function :
```javascript
ready: function() {
  this.connection = this.$.nx;
  ...
}
```
so why not use it ?