### PR TITLE
ELEMENTS-935: remove unused npm deps (2.2.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,17 +18,6 @@
     "lint": "npm run eslint",
     "test": "polymer test --simpleOutput --expanded -l chrome"
   },
-  "dependencies": {
-    "@polymer/polymer": "^1.2.5-npm-test.2",
-    "@polymer/iron-elements": "0.0.3",
-    "@polymer/paper-elements": "0.0.3",
-    "cropperjs": "^0.5.6",
-    "d3": "^3.5.16",
-    "moment": "^2.10.6",
-    "paper-typeahead": "nuxeo/paper-typeahead#0.4",
-    "video.js": "^5.5.3",
-    "select2": "3.5.2-browserify"
-  },
   "devDependencies": {
     "eslint": "^3.0.0",
     "eslint-plugin-html": "^2.0.0",


### PR DESCRIPTION
Backport of https://github.com/nuxeo/nuxeo-ui-elements/commit/82bc6dab1c754d77e2d56002230de3877d2a0a85 9.10.