### PR TITLE
ELEMENTS-1092: don't set the background color

### DIFF
--- a/nuxeo-document-permissions/nuxeo-document-permissions.html
+++ b/nuxeo-document-permissions/nuxeo-document-permissions.html
@@ -51,7 +51,6 @@ An element providing document permissions management
       .bubbleBox {
         @apply --nuxeo-document-permissions-box;
         @apply --paper-card;
-        background-color: #fff;
         box-shadow: 0 0 1px rgba(0, 0, 0, 0.2);
         display: block;
         padding: 0 1em 1em;


### PR DESCRIPTION
Not setting the background color in nuxeo-document-permissions will use the default background which matchs the font color, then the text will be visible.