### PR TITLE
NXP-28812: fix cancelation on multipart upload

### DIFF
--- a/widgets/nuxeo-uploader-behavior.html
+++ b/widgets/nuxeo-uploader-behavior.html
@@ -37,9 +37,7 @@ limitations under the License.
 
     DefaultUploadProvider.prototype._ensureBatch = function () {
       if (!this.batchAppend || !this.uploader) {
-        return this.connection.batchUpload().then((uploader) => {
-          this.uploader = uploader;
-        });
+        return this._newBatch();
       } else {
         return Promise.resolve();
       }
@@ -68,6 +66,9 @@ limitations under the License.
               callback({ type: 'uploadStarted', file });
             }
             this.uploader.upload(blob).then((result) => {
+              if (!this.batchId) {
+                callback({ type: 'batchStart', batchId: result.batch._batchId });
+              }
               callback({ type: 'uploadCompleted', fileIdx: result.blob.fileIdx });
             }).catch((error) => {
               callback({ type: 'uploadInterrupted', file, error });
@@ -312,6 +313,9 @@ limitations under the License.
             case 'uploadCompleted':
               this._uploadFinished(event.fileIdx);
               break;
+            case 'batchStart':
+              this._batchStart(event.batchId);
+              break;
             case 'batchFinished':
               this._batchFinished(event.batchId);
               break;
@@ -372,6 +376,12 @@ limitations under the License.
         Object.keys(values).forEach((k) => {
           this.set(['files', index, k].join('.'), values[k]);
         });
+      },
+
+      _batchStart(batchId) {
+        this.batchId = batchId;
+        this._instance.batchId = batchId;
+        this.fire('batchStart', { batchId });
       },
 
       _batchFinished(batchId) {


### PR DESCRIPTION
Related to: https://github.com/nuxeo/nuxeo-web-ui/pull/875

I made the changes on this element too to improve its behavior:
- reuse the method to initiate the batch.
- If a user uploads many files and at the middle he takes the choice to cancel his upload it will not work because the `batchId` will be undefined as we set it when we `batchFinished` but the `batchId` is available since the first upload, I added the code to set it which allows the user to cancel his upload at any time. 