### PR TITLE
ELEMENTS-1220: use Remove instead of Write permission in nuxeo-delete-document-button (10.10)

### DIFF
--- a/actions/nuxeo-delete-document-button.html
+++ b/actions/nuxeo-delete-document-button.html
@@ -114,7 +114,7 @@ limitations under the License.
 
         _isAvailable(doc) {
           return doc && !this.isVersion(doc) &&
-            this.hasPermission(doc, 'Write') && (!this.isTrashed(doc) || this.hard) &&
+            this.hasPermission(doc, 'Remove') && (!this.isTrashed(doc) || this.hard) &&
             !this.isUnderRetentionOrLegalHold(doc);
         }
 


### PR DESCRIPTION
Working accordingly in Web UI, but when trying to delete a document with only `Read` and `Remove` permissions, the server returns `403`. Needs further investigation on the server side before this can be merged.