### PR TITLE
ELEMENTS-1257: fix reset when fetching in page provider display behavior (10.10)

### DIFF
--- a/nuxeo-page-provider-display-behavior.html
+++ b/nuxeo-page-provider-display-behavior.html
@@ -597,7 +597,12 @@ limitations under the License.
               }
             }
             if (clear || this.items.length !== count) {
-              this.reset(count);
+              if (this.size >= 0) {
+                // size was explicitly set => reset according to the pageSize
+                this.reset(response.pageSize < count ? response.pageSize : count);
+              } else {
+                this.reset(count);
+              }
             }
 
             // fill items range based on response


### PR DESCRIPTION
Fixes the reset to take into account the current page size (if the page size is X, it should not show more than X entries).