### PR TITLE
ELEMENTS-1455: use WriteSecurity instead of Everything in document permissions (2.4.x)

### DIFF
--- a/nuxeo-document-permissions/nuxeo-document-permissions.html
+++ b/nuxeo-document-permissions/nuxeo-document-permissions.html
@@ -77,7 +77,7 @@ limitations under the License.
 
     <!-- Local permissions -->
     <nuxeo-card heading="[[i18n('documentPermissions.locallyDefined')]]">
-      <dom-if if="[[_hasPermission(doc,'Everything')]]">
+      <dom-if if="[[_hasPermission(doc)]]">
         <template>
           <div class="actions">
             <nuxeo-popup-permission id="localPermissions" doc-id="{{doc.uid}}"
@@ -88,7 +88,7 @@ limitations under the License.
       </dom-if>
       <div class="content">
         <nuxeo-document-acl-table doc="[[doc]]" acl-filter="_excludeInheritedAcls" ace-filter="_excludeExternalUserAces"
-          show-actions="[[_hasPermission(doc,'Everything')]]">
+          show-actions="[[_hasPermission(doc)]]">
           <div slot="emptyResult" class="emptyResult">[[_emptyLabel('documentPermissions.noLocalPermissions', loading, i18n)]]</div>
         </nuxeo-document-acl-table>
       </div>
@@ -96,7 +96,7 @@ limitations under the License.
 
     <!-- Inherited permissions -->
     <nuxeo-card heading="[[i18n('documentPermissions.inherited')]]">
-      <dom-if if="[[_hasPermission(doc,'Everything')]]">
+      <dom-if if="[[_hasPermission(doc)]]">
         <template>
           <div class="actions">
             <dom-if if="[[!_empty(inheritedAces)]]">
@@ -122,7 +122,7 @@ limitations under the License.
 
     <!-- External users permissions -->
     <nuxeo-card heading="[[i18n('documentPermissions.external')]]">
-      <dom-if if="[[_hasPermission(doc, 'Everything')]]">
+      <dom-if if="[[_hasPermission(doc)]]">
         <template>
           <div class="actions">
             <nuxeo-popup-permission id="externalPermissions" doc-id="{{doc.uid}}"
@@ -136,7 +136,7 @@ limitations under the License.
         <div class="tip">[[i18n('documentPermissions.externalDescription')]]</div>
         <nuxeo-document-acl-table doc="[[doc]]" ace-filter="_onlyExternalUserAces"
                                   acl-filter="_excludeInheritedAcls"
-                                  show-actions="[[_hasPermission(doc,'Everything')]]"
+                                  show-actions="[[_hasPermission(doc)]]"
                                   share-with-external="true">
           <div slot="emptyResult" class="emptyResult">[[_emptyLabel('documentPermissions.noExternalPermission', loading, i18n)]]</div>
         </nuxeo-document-acl-table>
@@ -243,7 +243,7 @@ limitations under the License.
 
         _hasPermission() {
           const permissions = this.doc && this.doc.contextParameters && this.doc.contextParameters.permissions;
-          return permissions && permissions.indexOf('Everything') !== -1;
+          return permissions && permissions.indexOf('WriteSecurity') !== -1;
         }
 
         _empty(arr) {


### PR DESCRIPTION
Backport of [nuxeo-elements/498](https://github.com/nuxeo/nuxeo-elements/pull/498).