### PR TITLE
ELEMENTS-1453: clear instance children from nuxeo-dialog

### DIFF
--- a/widgets/nuxeo-dialog.html
+++ b/widgets/nuxeo-dialog.html
@@ -86,7 +86,7 @@ limitations under the License.
           if (this._observer) {
             this.detached();
           }
-          this._instance = null;
+          this._clear();
         }
 
         _opened(e) {
@@ -105,6 +105,20 @@ limitations under the License.
               this._instance = this.stamp();
               this.appendChild(this._instance.root);
             }
+          }
+        }
+
+        _clear() {
+          if (this._instance) {
+            const c$ = this._instance.children;
+            if (c$ && c$.length) {
+              // use first child parent, for case when dom-if may have been detached
+              const parent = Polymer.dom(Polymer.dom(c$[0]).parentNode);
+              for (let i = 0, n; (i < c$.length) && (n = c$[i]); i++) {
+                parent.removeChild(n);
+              }
+            }
+            this._instance = null;
           }
         }
 


### PR DESCRIPTION
Note: it seems that `instance` nodes are not removed from the DOM when the `nuxeo-dialog` is closed or detached. This pollutes the DOM with multiple nodes that should have been removed in the first place, and as a side-effect we get the incorrect preview, always showing the initial picture preview.