### PR TITLE
ELEMENTS-1399: placeholder resizing in nuxeo-tag-suggestion

### DIFF
--- a/widgets/selectivity/selectivity.js
+++ b/widgets/selectivity/selectivity.js
@@ -3372,8 +3372,12 @@ var callSuper = Selectivity.inherits(MultipleInput, Selectivity, {
     _updateInputWidth: function() {
         var inputContent =
             this.input.value || (!this._data.length && this.options.placeholder) || '';
-        this.input.setAttribute('size', inputContent.length + 2);
-
+        const placeholderLength = this.options.placeholder != null && this.options.placeholder.length;
+        if (this.enabled && !this._data.length && inputContent.length <= placeholderLength) {
+            this.input.setAttribute('size', placeholderLength);
+        } else {
+            this.input.setAttribute('size', inputContent.length + 2);
+        }
         this.positionDropdown();
     },
 


### PR DESCRIPTION
https://jira.nuxeo.com/browse/ELEMENTS-1399
Previously:

Assume the user enters nature in Tag, so the size becomes 6 (nature lengths).
Instead of adding the Tag(nature), move the cursor anywhere on the page.
As a result, the size value remains '6'.
Due to this we used to see only six characters in placeholders like Add ta.
But when user do not add any Tag then by default the size value should be 25 "Add tags to this document" length is 25 .