### PR TITLE
Fix some videos cannot play on video viewer

### DIFF
--- a/nuxeo-document-preview.js
+++ b/nuxeo-document-preview.js
@@ -252,7 +252,7 @@ import './viewers/nuxeo-video-viewer.js';
     }
 
     _computeVideoSources() {
-      if (this.document && this.document.properties && this.document.properties['vid:transcodedVideos']
+      if (this.document && this.document.properties && this.document.properties['vid:transcodedVideos']?.length > 0
           && this.xpath === 'file:content') {
         const conversions = [];
         this.document.properties['vid:transcodedVideos'].forEach((conversion) => {


### PR DESCRIPTION
`vid:transcodedVideos` is empty (an empty array) before any VideoConversionWork complete successfully. By falling back video source to the blob itself, the video viewer can play videos even when `vid:transcodedVideos` is empty.